### PR TITLE
Fix numerous issues found during C# port experiment

### DIFF
--- a/addons/tiltfive_tools/functions/pointer.gd
+++ b/addons/tiltfive_tools/functions/pointer.gd
@@ -51,9 +51,6 @@ const VALID_MASK := 0b0000_0000_0001_0000_0000_0000_0000_0000
 
 @export_group("Arc")
 
-## Arc length when not colliding
-@export_range(0.01, 1.0, 0.01, "or_greater") var not_colliding_distance : float = 0.5
-
 ## Bezier strength
 @export_range(0.1, 1.0, 0.05) var bezier_strength : float = 0.5
 

--- a/addons/tiltfive_tools/functions/visible_toggle.gd
+++ b/addons/tiltfive_tools/functions/visible_toggle.gd
@@ -16,7 +16,7 @@ enum Initial {
 
 
 ## Wand number (0 for default)
-@export var wand : int = 2
+@export var wand : int = 0
 
 ## Toggle button (T5 menu button for default)
 @export var toggle_button : String = "button_t5"

--- a/addons/tiltfive_tools/objects/controllers/characterbody_controller.gd
+++ b/addons/tiltfive_tools/objects/controllers/characterbody_controller.gd
@@ -237,9 +237,9 @@ func _control_to_global(control : Vector2) -> Vector3:
 	var vec : Vector3
 	match control_orientation:
 		ControlOrientation.VERTICAL:
-			vec = Vector3(_control.x, 0.0, -_control.y)
+			vec = Vector3(control.x, 0.0, -control.y)
 		ControlOrientation.HORIZONTAL:
-			vec = Vector3(-_control.y, 0.0, -_control.x)
+			vec = Vector3(-control.y, 0.0, -control.x)
 
 	# Translate to reference frame
 	if control_reference == ControlReference.PLAYER:

--- a/addons/tiltfive_tools/objects/controllers/rigidbody_controller.gd
+++ b/addons/tiltfive_tools/objects/controllers/rigidbody_controller.gd
@@ -181,7 +181,7 @@ func _is_on_ground() -> bool:
 			continue
 
 		# Test if moving up relative to the ground
-		var ground_velocity := collision.get_collider_velocity(0)
+		var ground_velocity := collision.get_collider_velocity(c)
 		var relative_velocity := linear_velocity - ground_velocity
 		if relative_velocity.y > 0.1:
 			continue
@@ -199,9 +199,9 @@ func _control_to_global(control : Vector2) -> Vector3:
 	var vec : Vector3
 	match control_orientation:
 		ControlOrientation.VERTICAL:
-			vec = Vector3(_control.x, 0.0, -_control.y)
+			vec = Vector3(control.x, 0.0, -control.y)
 		ControlOrientation.HORIZONTAL:
-			vec = Vector3(-_control.y, 0.0, -_control.x)
+			vec = Vector3(-control.y, 0.0, -control.x)
 
 	# Translate to reference frame
 	if control_reference == ControlReference.PLAYER:

--- a/addons/tiltfive_tools/objects/scene_switch_area.gd
+++ b/addons/tiltfive_tools/objects/scene_switch_area.gd
@@ -1,5 +1,5 @@
 @tool
-class_name SceneSwitchArea
+class_name T5ToolsSceneSwitchArea
 extends Area3D
 
 
@@ -25,7 +25,7 @@ func _ready() -> void:
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings := PackedStringArray()
 
-	# Verify the controller
+	# Verify the target scene is specified
 	if not target_scene:
 		warnings.append("Target scene must be specified")
 

--- a/addons/tiltfive_tools/staging/player.gd
+++ b/addons/tiltfive_tools/staging/player.gd
@@ -14,7 +14,27 @@ extends T5XRRig
 @export_flags_3d_render var visible_layers : int = 5 : set = _set_visible_layers
 
 ## Player number [0..3] (set by Staging on load)
-@export var player_number : int : set = _set_player_number
+@export var player_number : int = -1 : set = _set_player_number
+
+
+## Array of all players (used for player numbering)
+static var _players : Array[T5ToolsPlayer] = []
+
+
+func _enter_tree():
+	# Assign the next free player number
+	for n in 4:
+		if _players.all(func(p : T5ToolsPlayer) -> bool: return p.player_number != n):
+			player_number = n
+			break;
+
+	# Save as a player
+	_players.append(self)
+
+
+func _exit_tree():
+	# Remove from the list of players
+	_players.erase(self)
 
 
 func _ready():

--- a/addons/tiltfive_tools/staging/scene.gd
+++ b/addons/tiltfive_tools/staging/scene.gd
@@ -29,7 +29,7 @@ var characters : Array[T5ToolsCharacter] = []
 
 
 ## Load spawn point
-var _load_spawn : Transform3D
+var _load_spawn : Transform3D = Transform3D.IDENTITY
 
 
 func _ready():
@@ -49,7 +49,6 @@ func _on_scene_loaded(user_data : Variant) -> void:
 		spawn_position = spawn_position.get_spawn_postion(self)
 
 	# Get the spawn transform
-	var _load_spawn := Transform3D.IDENTITY
 	match typeof(spawn_position):
 		TYPE_STRING:
 			# Name of Node3D to spawn at

--- a/addons/tiltfive_tools/staging/staging.tscn
+++ b/addons/tiltfive_tools/staging/staging.tscn
@@ -40,6 +40,3 @@ script = ExtResource("2_1ijo2")
 glasses_scene = ExtResource("3_pw71e")
 
 [node name="Scene" type="Node3D" parent="."]
-
-[connection signal="glasses_scene_was_added" from="T5Manager" to="." method="_on_player_scene_added"]
-[connection signal="glasses_scene_will_be_removed" from="T5Manager" to="." method="_on_player_scene_removed"]


### PR DESCRIPTION
This PR fixes the following issues that were found while performing the experimental C# port.

- #5 = Now uses _load_spawn field
- #6 = Now uses XRToolsStaging name
- #7 = Now wires player signals in code
- #8 = Now uses T5ToolsSceneSwitchArea name
- #9 = Fixes invalid comment
- #10 = Removes unused export
- #11 = Sets default wand to 0
- #12 = Uses argument rather than field
- #13 = Tests correct collider 'c'
- #14 = Manages player_number in XRToolsPlayer during _enter_tree