### PR TITLE
Add viewport visibility change notifications

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,3 +1,7 @@
+# 1.2.0 (in development)
+- Notify viewport scenes of visibility changes
+- Add T5ToolsViewport2Din3D class name for gdscript
+
 # 1.1.0
 - Update to Godot/T5 Icon
 - Migrated TiltFiveTools to latest TiltFiveGodot4 API

--- a/project.csharp/addons/tiltfive_tools/objects/viewport/T5ToolsViewport2Din3D.cs
+++ b/project.csharp/addons/tiltfive_tools/objects/viewport/T5ToolsViewport2Din3D.cs
@@ -348,7 +348,7 @@ public partial class T5ToolsViewport2Din3D : Node3D
         body.PointerEvent += OnPointerEvent;
 
         // Update enabled based on visibility
-        VisibilityChanged += UpdateEnabled;
+        VisibilityChanged += OnVisibilityChanged;
 
         // Apply physics properties
         UpdateScreenSize();
@@ -492,6 +492,19 @@ public partial class T5ToolsViewport2Din3D : Node3D
             // This is no longer needed
             SetProcess(false);
         }
+    }
+
+    /// <summary>
+    /// Handle visibility changed
+    /// </summary>
+    private void OnVisibilityChanged()
+    {
+        // Update enabled state
+        UpdateEnabled();
+
+        // Fire visibility changed in scene
+        _sceneNode?.PropagateNotification(
+            (int)CanvasItem.NotificationVisibilityChanged);
     }
 
     /// <summary>

--- a/project.gd/addons/tiltfive_tools/objects/viewport/viewport_2d_in_3d.gd
+++ b/project.gd/addons/tiltfive_tools/objects/viewport/viewport_2d_in_3d.gd
@@ -1,4 +1,5 @@
 @tool
+class_name T5ToolsViewport2Din3D
 extends Node3D
 
 
@@ -127,7 +128,7 @@ func _ready():
 	$StaticBody3D.connect("pointer_event", _on_pointer_event)
 
 	# Update enabled based on visibility
-	visibility_changed.connect(_update_enabled)
+	visibility_changed.connect(_on_visibility_changed)
 
 	# Apply physics properties
 	_update_screen_size()
@@ -242,6 +243,17 @@ func _process(delta):
 	else:
 		# This is no longer needed
 		set_process(false)
+
+
+# Handle visibility changed
+func _on_visibility_changed() -> void:
+	# Update enabled state
+	_update_enabled()
+
+	# Fire visibility changed in scene
+	if scene_node:
+		scene_node.propagate_notification(
+			CanvasItem.NOTIFICATION_VISIBILITY_CHANGED)
 
 
 ## Set screen size property


### PR DESCRIPTION
This PR resolves issue #22 by firing NOTIFICATION_VISIBILITY_CHANGED on the contents of Viewport2Din3D scenes so they can react to becoming visible and update their content.

Additionally it resolves issue #20 by giving a class_name to the gdscript version of T5ToolsViewport2Din3D.